### PR TITLE
PDOK- 13165 getfeatureinfo

### DIFF
--- a/operations/error.go
+++ b/operations/error.go
@@ -55,12 +55,19 @@ func (w WMTSException) Status() int {
 
 // MissingParameterValue template
 func MissingParameterValue(value string) Exception {
-	return WMTSException{ErrorMessage: fmt.Sprintf("Missing parameter: %s", value), ErrorCode: "MissingParameterValue", StatusCode: 400}
+	return WMTSException{ErrorMessage: fmt.Sprintf("Missing parameter: %s", value),
+		ErrorCode: "MissingParameterValue", StatusCode: 400}
 }
 
 // UnknownService template
 func UnknownService(value string) Exception {
-	return WMTSException{ErrorMessage: fmt.Sprintf("Missing SERVICE key or incorrect value, found: %s", value), ErrorCode: "MissingParameterValue", StatusCode: 400}
+	return WMTSException{ErrorMessage: fmt.Sprintf("Missing SERVICE key or incorrect value, found: %s", value),
+		ErrorCode: "MissingParameterValue", StatusCode: 400}
+}
+
+func InvalidParameterValue(parameter string, value string) Exception {
+	return WMTSException{ErrorMessage: fmt.Sprintf("InvalidParameterValue for parameter: %s with value: %s",
+		parameter, value), ErrorCode: "InvalidParameterValue", StatusCode: 400}
 }
 
 // SendError writes the error message to the response

--- a/operations/getfeatureinfo.go
+++ b/operations/getfeatureinfo.go
@@ -1,0 +1,93 @@
+package operations
+
+import (
+	"bytes"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"text/template"
+)
+
+var getFeatureInfoRegex = regexp.MustCompile(`^.*:(.*)$`)
+
+const getFeatureInfoRestTemplate = `/{{ .Layer }}/{{ .TileMatrixSet }}/{{ .TileMatrix }}/{{ .TileRow }}/{{ .TileCol }}/{{ .J }}/{{ .I }}{{ .FileExtension }}`
+
+// ProcessGetFeatureInfoRequest - Translates KVP requests to RestFUL requests
+func ProcessGetFeatureInfoRequest(w http.ResponseWriter, r *http.Request) Exception {
+	wmtskeys, otherkeys := splitQueryKeys(r.URL.Query(), getFeatureInfoKeys())
+	err := missingKeys(wmtskeys, getFeatureInfoKeys())
+	if err != nil {
+		return err
+	}
+
+	url, err := getFeatureInfoQueryToPath(wmtskeys)
+	if err != nil {
+		return err
+	}
+
+	r.URL.Path = strings.TrimRight(r.URL.Path, "/") + url
+	if len(otherkeys) > 0 {
+		r.URL.RawQuery = formatKeysToQueryString(otherkeys)
+	} else {
+		r.URL.RawQuery = ""
+	}
+	return nil
+}
+
+func getFeatureInfoQueryToPath(query url.Values) (string, Exception) {
+
+	type RestParameters struct {
+		Layer         string
+		TileMatrixSet string
+		TileMatrix    string
+		TileCol       string
+		TileRow       string
+		I             string
+		J             string
+		FileExtension string
+	}
+
+	tilematrix := query["tilematrix"][0]
+	groups := getFeatureInfoRegex.FindAllStringSubmatch(tilematrix, -1)
+	if groups != nil {
+		tilematrix = groups[0][1]
+	}
+
+	fileExtension, err := parseFileExtension(query["infoformat"][0])
+	if err != nil {
+		return "", err
+	}
+
+	restParameters := &RestParameters{Layer: query["layer"][0], TileMatrixSet: query["tilematrixset"][0],
+		TileMatrix: tilematrix, TileCol: query["tilecol"][0], TileRow: query["tilerow"][0],
+		I: query["i"][0], J: query["j"][0], FileExtension: fileExtension}
+
+	buf := new(bytes.Buffer)
+	template.Must(template.New("getFeatureInfoResttemplate").Parse(getFeatureInfoRestTemplate)).Execute(buf, restParameters)
+
+	return buf.String(), nil
+}
+
+func parseFileExtension(format string) (string, Exception) {
+
+	fileExtension := format
+	switch fileExtension {
+	case "plain/text":
+		fileExtension = ".txt"
+	case "text/html":
+		fileExtension = ".html"
+	case "application/json":
+		fileExtension = ".json"
+	case "text/xml":
+		fileExtension = ".xml"
+	default:
+		return "", InvalidParameterValue("infoformat", fileExtension)
+	}
+	return fileExtension, nil
+}
+
+// GetCapabilitiesKeys list of manitory WMTS gettile key value pairs
+func getFeatureInfoKeys() []string {
+	return []string{"service", "request", "version", "layer", "tilematrixset", "tilematrix", "tilecol", "tilerow", "i", "j", "infoformat"}
+}

--- a/operations/getfeatureinfo_test.go
+++ b/operations/getfeatureinfo_test.go
@@ -1,0 +1,82 @@
+package operations
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestParseInfoFormat(t *testing.T) {
+	format := "plain/text"
+	expected := ".txt"
+	result, err := parseFileExtension(format)
+	if err != nil || result != expected {
+		t.Errorf("Expected format is: %s but was: %s", expected, result)
+	}
+}
+
+func TestParseInvalidInfoFormat(t *testing.T) {
+	format := "image/png"
+	expected := ""
+	result, err := parseFileExtension(format)
+	if result != "" || err.Code() != "InvalidParameterValue" {
+		t.Errorf("Expected format is: %s but was: %s", expected, err.Code())
+	}
+}
+
+func TestProcessGetFeatureInfoRequest(t *testing.T) {
+	var mockRequest = &http.Request{
+		Method: "GET",
+		Host:   "example.com",
+		URL: &url.URL{Path: "local", RawQuery: "service=WMTS&request=GetFeatureInfo&version=1.0.0" +
+			"&layer=achtergrondvisualisatie&tilematrixset=EPSG:28992&tilematrix=14" +
+			"&tilecol=col&tilerow=row&infoformat=text/plain&j=1&i=2&testkey=testvalue"},
+		Header:     http.Header{},
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		RemoteAddr: "192.0.2.1:1234",
+	}
+	expected := "local/achtergrondvisualisatie/EPSG:28992/14/row/col/1/2.txt"
+	ts := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ProcessGetFeatureInfoRequest(w, mockRequest)
+		}))
+	defer ts.Close()
+
+	http.Get(ts.URL)
+
+	if mockRequest.URL.String() != expected {
+		t.Errorf("Expected %s but was not, got: %s", expected, mockRequest.URL.String())
+	}
+}
+
+func TestProcessGetFeatureInfoRequestMissingKeys(t *testing.T) {
+	var err Exception
+	var mockRequest = &http.Request{
+		Method: "GET",
+		Host:   "example.com",
+		URL: &url.URL{Path: "local", RawQuery: "service=WMTS&request=GetFeatureInfo&version=1.0.0" +
+			"&layer=achtergrondvisualisatie&tilematrix=14" +
+			"&tilecol=col&tilerow=row&infoformat=text/plain&j=1&i=2&testkey=testvalue"},
+		Header:     http.Header{},
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		RemoteAddr: "192.0.2.1:1234",
+	}
+	expected := "Missing parameter: tilematrixset"
+	ts := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err = ProcessGetTileRequest(w, mockRequest)
+		}))
+	defer ts.Close()
+
+	http.Get(ts.URL)
+
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("Expected %s but was not, got: %s", expected, err.Error())
+	}
+}

--- a/operations/getfeatureinfo_test.go
+++ b/operations/getfeatureinfo_test.go
@@ -32,14 +32,14 @@ func TestProcessGetFeatureInfoRequest(t *testing.T) {
 		Host:   "example.com",
 		URL: &url.URL{Path: "local", RawQuery: "service=WMTS&request=GetFeatureInfo&version=1.0.0" +
 			"&layer=achtergrondvisualisatie&tilematrixset=EPSG:28992&tilematrix=14" +
-			"&tilecol=col&tilerow=row&infoformat=text/plain&j=1&i=2&testkey=testvalue"},
+			"&tilecol=col&tilerow=row&infoformat=plain/text&j=1&i=2&testkey=testvalue"},
 		Header:     http.Header{},
 		Proto:      "HTTP/1.1",
 		ProtoMajor: 1,
 		ProtoMinor: 1,
 		RemoteAddr: "192.0.2.1:1234",
 	}
-	expected := "local/achtergrondvisualisatie/EPSG:28992/14/row/col/1/2.txt"
+	expected := "local/achtergrondvisualisatie/EPSG:28992/14/row/col/1/2.txt?testkey=testvalue"
 	ts := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ProcessGetFeatureInfoRequest(w, mockRequest)

--- a/operations/operations.go
+++ b/operations/operations.go
@@ -114,6 +114,13 @@ func ProcessRequest(config *Config, w http.ResponseWriter, r *http.Request) bool
 			return false
 		}
 		return false
+	case "getfeatureinfo":
+		err := ProcessGetFeatureInfoRequest(w, r)
+		if err != nil {
+			SendError(err, w, r)
+			return false
+		}
+		return true
 	default:
 		return true
 	}


### PR DESCRIPTION
# Omschrijving

Een omschrijving van wat je hebt toegevoegd/veranderd:

Uitbreiding van de wmts-kvp-to-restful. Hierdoor worden GetFeatureInfo requesten ook ondersteund. 

https://dev.kadaster.nl/jira/browse/PDOK-13165

## Type verandering

(Verwijder de opties die niet relevant zijn.)

- Nieuwe feature


# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [x] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)