### PR TITLE
PDOK-13165 - Switch TileRow and TileCol

### DIFF
--- a/operations/getfeatureinfo.go
+++ b/operations/getfeatureinfo.go
@@ -11,7 +11,8 @@ import (
 
 var getFeatureInfoRegex = regexp.MustCompile(`^.*:(.*)$`)
 
-const getFeatureInfoRestTemplate = `/{{ .Layer }}/{{ .TileMatrixSet }}/{{ .TileMatrix }}/{{ .TileRow }}/{{ .TileCol }}/{{ .J }}/{{ .I }}{{ .FileExtension }}`
+// Although the spc indices that TileRow must supersede TileCol, this does not seem to work.
+const getFeatureInfoRestTemplate = `/{{ .Layer }}/{{ .TileMatrixSet }}/{{ .TileMatrix }}/{{ .TileCol }}/{{ .TileRow }}/{{ .J }}/{{ .I }}{{ .FileExtension }}`
 
 // ProcessGetFeatureInfoRequest - Translates KVP requests to RestFUL requests
 func ProcessGetFeatureInfoRequest(w http.ResponseWriter, r *http.Request) Exception {


### PR DESCRIPTION
# Omschrijving

Een omschrijving van wat je hebt toegevoegd/veranderd:

Volgens de spec zou de TileRow voor de TileCol moeten komen maar in de praktijk werkt dit niet. 

![image](https://user-images.githubusercontent.com/15123825/145229123-d0273df2-bbbb-45aa-a2d8-556e6858e8b6.png)


https://dev.kadaster.nl/jira/browse/PDOK-13165

## Type verandering

(Verwijder de opties die niet relevant zijn.)

- Minor change (typo, formatting, version bump)
- Nieuwe feature
- Verbetering oude feature
- Bugfix
- Refactor
- Aanpassing van de configuratie
- Breaking change

# Checklist:

- [ ] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [ ] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)