### PR TITLE
Swap I and J parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ ENV CGO_ENABLED=1
 #compile linux only
 ENV GOOS=linux
 
+#run all tests
+RUN go test github.com/PDOK/wmts-kvp-to-restful/operations
+
 #build the binary with debug information removed
 RUN go build -ldflags '-w -s -linkmode external -extldflags -static' -a -installsuffix cgo -o /wmts-kvp-to-restful .
 

--- a/operations/getfeatureinfo.go
+++ b/operations/getfeatureinfo.go
@@ -12,7 +12,7 @@ import (
 var getFeatureInfoRegex = regexp.MustCompile(`^.*:(.*)$`)
 
 // Although the spc indices that TileRow must supersede TileCol, this does not seem to work.
-const getFeatureInfoRestTemplate = `/{{ .Layer }}/{{ .TileMatrixSet }}/{{ .TileMatrix }}/{{ .TileCol }}/{{ .TileRow }}/{{ .J }}/{{ .I }}{{ .FileExtension }}`
+const getFeatureInfoRestTemplate = `/{{ .Layer }}/{{ .TileMatrixSet }}/{{ .TileMatrix }}/{{ .TileCol }}/{{ .TileRow }}/{{ .I }}/{{ .J }}{{ .FileExtension }}`
 
 // ProcessGetFeatureInfoRequest - Translates KVP requests to RestFUL requests
 func ProcessGetFeatureInfoRequest(w http.ResponseWriter, r *http.Request) Exception {

--- a/operations/getfeatureinfo.go
+++ b/operations/getfeatureinfo.go
@@ -11,7 +11,6 @@ import (
 
 var getFeatureInfoRegex = regexp.MustCompile(`^.*:(.*)$`)
 
-// Although the spc indices that TileRow must supersede TileCol, this does not seem to work.
 const getFeatureInfoRestTemplate = `/{{ .Layer }}/{{ .TileMatrixSet }}/{{ .TileMatrix }}/{{ .TileCol }}/{{ .TileRow }}/{{ .I }}/{{ .J }}{{ .FileExtension }}`
 
 // ProcessGetFeatureInfoRequest - Translates KVP requests to RestFUL requests

--- a/operations/getfeatureinfo_test.go
+++ b/operations/getfeatureinfo_test.go
@@ -39,7 +39,7 @@ func TestProcessGetFeatureInfoRequest(t *testing.T) {
 		ProtoMinor: 1,
 		RemoteAddr: "192.0.2.1:1234",
 	}
-	expected := "local/achtergrondvisualisatie/EPSG:28992/14/row/col/1/2.txt?testkey=testvalue"
+	expected := "local/achtergrondvisualisatie/EPSG:28992/14/row/col/2/1.txt?testkey=testvalue"
 	ts := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ProcessGetFeatureInfoRequest(w, mockRequest)

--- a/operations/getfeatureinfo_test.go
+++ b/operations/getfeatureinfo_test.go
@@ -39,7 +39,7 @@ func TestProcessGetFeatureInfoRequest(t *testing.T) {
 		ProtoMinor: 1,
 		RemoteAddr: "192.0.2.1:1234",
 	}
-	expected := "local/achtergrondvisualisatie/EPSG:28992/14/row/col/2/1.txt?testkey=testvalue"
+	expected := "local/achtergrondvisualisatie/EPSG:28992/14/col/row/2/1.txt?testkey=testvalue"
 	ts := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ProcessGetFeatureInfoRequest(w, mockRequest)


### PR DESCRIPTION
# Omschrijving

Klein vuiltje in afhandeling GetFeatureInfo: volgorde i en j parameters wijkt af van wat MapProxy verwacht. Daarnaast bleek een unittest stuk en werden de unittest niet uitgevoerd als onderdeel van de docker build.

https://dev.kadaster.nl/jira/browse/PDOK-13766

- Bugfix

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [x] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [ ] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)